### PR TITLE
Fix typescript codegen inheritance

### DIFF
--- a/api/privdoc/spec/definitions/RUSDomesticPassport.yaml
+++ b/api/privdoc/spec/definitions/RUSDomesticPassport.yaml
@@ -3,10 +3,6 @@ allOf:
   - $ref: '#/definitions/SecuredPrivateDocument'
   - type: object
     properties:
-      type:
-        description: Национальный паспорт гражданина РФ
-        type: string
-        readOnly: true
       seriesMasked:
         description: Маскированная серия паспорта
         type: string

--- a/api/privdoc/spec/definitions/RUSDomesticPassportData.yaml
+++ b/api/privdoc/spec/definitions/RUSDomesticPassportData.yaml
@@ -13,9 +13,6 @@ allOf:
       - birthDate
       - birthPlace
     properties:
-      type:
-        description: Национальный паспорт гражданина РФ
-        type: string
       series:
         description: Серия паспорта
         type: string

--- a/api/privdoc/spec/definitions/RUSRetireeInsuranceCertificate.yaml
+++ b/api/privdoc/spec/definitions/RUSRetireeInsuranceCertificate.yaml
@@ -5,11 +5,6 @@ allOf:
   - $ref: '#/definitions/SecuredPrivateDocument'
   - type: object
     properties:
-      type:
-        description: |
-          Страховое свидетельство обязательного пенсионного страхования
-        type: string
-        readOnly: true
       numberMasked:
         description: |
           Маскированный [СНИЛС](https://ru.wikipedia.org/wiki/Страховой_номер_индивидуального_лицевого_счёта)

--- a/api/privdoc/spec/definitions/RUSRetireeInsuranceCertificateData.yaml
+++ b/api/privdoc/spec/definitions/RUSRetireeInsuranceCertificateData.yaml
@@ -7,10 +7,6 @@ allOf:
     required:
       - number
     properties:
-      type:
-        description: |
-          Страховое свидетельство обязательного пенсионного страхования
-        type: string
       number:
         description: |
           [СНИЛС](https://ru.wikipedia.org/wiki/Страховой_номер_индивидуального_лицевого_счёта)


### PR DESCRIPTION
Если в наследнике у property переопределить type, то это приводит к некорректной генерации typescript кода.
Пример swagger: 
Родитель: `SecuredPrivateDocument`:
```yaml
...
properties:
  type:
    x-rebillyMerge:
      - $ref: '#/definitions/SecuredPrivateDocumentType'
      - readOnly: true
...
```
Наследник:  `RUSDomesticPassport`
```yaml
...
allOf:
  - $ref: '#/definitions/SecuredPrivateDocument'
  - type: object
    properties:
      type:
        description: Национальный паспорт гражданина РФ
        type: string
        readOnly: true
...
```
В typescript такое наследование неккоректно:
```
Interface 'RUSDomesticPassport' incorrectly extends interface 'SecuredPrivateDocument'.
  Types of property 'type' are incompatible.
    Type 'string' is not assignable to type 'TypeEnum'
```